### PR TITLE
feat: チャット機能の基盤を構築、ユーザー・商品データの関係を整理してシーディング対応

### DIFF
--- a/src/app/Models/ChatMessage.php
+++ b/src/app/Models/ChatMessage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ChatMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'sender_id',
+        'content',
+        'image',
+    ];
+
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    public function reads()
+    {
+        return $this->hasMany(ChatMessageRead::class);
+    }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+}

--- a/src/app/Models/ChatMessageRead.php
+++ b/src/app/Models/ChatMessageRead.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ChatMessageRead extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'chat_message_id',
+        'user_id',
+        'read_at',
+    ];
+
+    public function message()
+    {
+        return $this->belongsTo(ChatMessage::class, 'chat_message_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/Order.php
+++ b/src/app/Models/Order.php
@@ -36,5 +36,10 @@ class Order extends Model
     {
         return $this->belongsTo(OrderAddress::class);
     }
+    // この注文に紐づくチャットメッセージ
+    public function chatMessages()
+    {
+        return $this->hasMany(ChatMessage::class);
+    }
 
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -51,6 +51,18 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(OrderAddress::class);
     }
 
+    // ユーザーが送信したメッセージ
+    public function chatMessages()
+    {
+        return $this->hasMany(ChatMessage::class, 'sender_id');
+    }
+
+    // ユーザーが既読にしたメッセージ
+    public function readChatMessages()
+    {
+        return $this->hasMany(ChatMessageRead::class);
+    }
+
     /**
      * The attributes that should be hidden for serialization.
      *

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -22,7 +22,9 @@ class UserFactory extends Factory
             'address' => $this->faker->address(),
             'postal_code' => $this->faker->postcode(),
             'building' => $this->faker->secondaryAddress(),
-            'profile_image' => '/storage/images/default.png'
+            'profile_image' => 'images/default.png',
+            'email_verified_at' => now(), // デフォルト認証済みに
+            'profile_completed' => true, // デフォルト完了済みに
         ];
     }
 

--- a/src/database/migrations/2025_06_02_111107_create_chat_messages_table.php
+++ b/src/database/migrations/2025_06_02_111107_create_chat_messages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChatMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('chat_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->onDelete('cascade');
+            $table->foreignId('sender_id')->constrained('users')->onDelete('cascade');
+            $table->text('content');
+            $table->string('image')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('chat_messages');
+    }
+}

--- a/src/database/migrations/2025_06_02_111143_create_chat_message_reads_table.php
+++ b/src/database/migrations/2025_06_02_111143_create_chat_message_reads_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChatMessageReadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('chat_message_reads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_message_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+    
+            $table->unique(['chat_message_id', 'user_id']); // 同一ユーザーが1回しか記録されないように
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('chat_message_reads');
+    }
+}

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -20,8 +20,8 @@ class DatabaseSeeder extends Seeder
         // カテゴリー（categories）を次にシーディング
         $this->call(CategorySeeder::class);
 
-        // ユーザーをファクトリで作成（10人分）
-        User::factory(10)->create();
+        // ユーザーをファクトリで作成
+        $this->call(UserSeeder::class);
 
         // 商品をシーディング（user_id, brand_id を利用）
         $this->call(ProductSeeder::class);

--- a/src/database/seeders/ProductSeeder.php
+++ b/src/database/seeders/ProductSeeder.php
@@ -17,7 +17,8 @@ class ProductSeeder extends Seeder
      */
     public function run()
     {
-        $user = User::first(); // 最初のユーザーを取得
+        $userA = User::where('email', 'usera@example.com')->first();
+        $userB = User::where('email', 'userb@example.com')->first();
 
         // 各テーブルのIDを取得
         $categories = Category::pluck('id', 'name')->toArray();
@@ -107,10 +108,10 @@ class ProductSeeder extends Seeder
             ],
         ];
 
-        foreach ($products as $productData) {
+        foreach ($products as $index => $productData) {
                 $product = Product::create([
                 'name' => $productData['name'],
-                'user_id' => $user->id,
+                'user_id' => $index < 5 ? $userA->id : $userB->id,
                 'price' => $productData['price'],
                 'description' => $productData['description'],
                 'image' => $productData['img'],

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // 出品者A（指定データで作成）
+        User::factory()->create([
+            'name' => 'ユーザーA',
+            'email' => 'usera@example.com',
+            'profile_image' => 'images/usera.png',
+        ]);
+
+        // 出品者B（指定データで作成）
+        User::factory()->create([
+            'name' => 'ユーザーB',
+            'email' => 'userb@example.com',
+            'profile_image' => 'images/userb.png',
+        ]);
+
+        // 商品を出品していないユーザーC（指定データで作成）
+        User::factory()->create([
+            'name' => 'ユーザーC',
+            'email' => 'userc@example.com',
+            'profile_image' => 'images/userc.png',
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要
チャット機能構築のための下準備として、ユーザー・商品データのダミー作成および画像パスの修正。

## 主な変更内容
- ユーザーSeederの作成（3ユーザー）
- ProductSeederを修正し、特定のユーザーに商品を紐づけ
- public/storage/images に画像パスを修正
- `php artisan storage:link` による画像表示対応
